### PR TITLE
Now we can set match response property to function for better support…

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -480,14 +480,16 @@ var EasyAutocomplete = (function(scope) {
 
 						function checkInputPhraseMatchResponse(inputPhrase, data) {
 
-							if (config.get("matchResponseProperty") !== false || typeof config.get("matchResponseProperty") === "string") {
-
-								if (data[config.get("matchResponseProperty")] == inputPhrase) {
-									return true;
-								} else {
-									return false;
+							if (config.get("matchResponseProperty") !== false) {
+								if (typeof config.get("matchResponseProperty") === "string") {
+									return (data[config.get("matchResponseProperty")] == inputPhrase);
 								}
 
+								if (typeof config.get("matchResponseProperty") === "function") {
+									return (config.get("matchResponseProperty")(data) === inputPhrase);
+								}
+
+								return true;
 							} else {
 								return true;
 							}


### PR DESCRIPTION
If we use json-rpc for response it's not possible to check where is "matchResponseProperty" located. We have to use same way as we do for listLocation.