### PR TITLE
Format the license in package.json to match the SPDX standard

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,10 +23,7 @@
   "bugs": {
     "url": "https://github.com/pawelczak/EasyAutocomplete/issues"
   },
-  "license": {
-    "type": "MIT",
-    "url": "https://github.com/pawelczak/easy-autocomplete/blob/master/LICENSE.txt"
-  },
+  "license": "MIT",
   "scripts": {
     "grunt": "grunt",
     "build": "npm run grunt build",


### PR DESCRIPTION
As documented on the NPM documentation (https://docs.npmjs.com/files/package.json#license). The license field has to comply with the SPDX specification for communicating the licenses and copyrights associated with a software package. This commit changes the license to a valid SPDX value (MIT)