### PR TITLE
Removing matchResponseProperty. It contained an issue where if respon…

### DIFF
--- a/src/configuration.js
+++ b/src/configuration.js
@@ -25,8 +25,6 @@ var EasyAutocomplete = (function(scope){
 
 			ajaxCallback: function() {},
 
-			matchResponseProperty: false,
-
 			list: {
 				sort: {
 					enabled: false,

--- a/src/core.js
+++ b/src/core.js
@@ -23,6 +23,7 @@ var EasyAutocomplete = (function(scope) {
 			$container = "",
 			elementsList = [],
 			selectedElement = -1,
+			remoteRequestCount = 0,
 			requestDelayTimeoutId;
 
 		scope.consts = consts;
@@ -493,11 +494,12 @@ var EasyAutocomplete = (function(scope) {
 
 					function loadData(inputPhrase) {
 
-
 						if (inputPhrase.length < config.get("minCharNumber")) {
 							return;
 						}
-
+						
+						remoteRequestCount += 1;
+						var capturedRequestCount = remoteRequestCount;
 
 						if (config.get("data") !== "list-required") {
 
@@ -529,7 +531,6 @@ var EasyAutocomplete = (function(scope) {
 							settings.dataType = config.get("dataType");
 						}
 
-
 						if (settings.url !== undefined && settings.url !== "list-required") {
 
 							settings.url = settings.url(inputPhrase);
@@ -545,9 +546,7 @@ var EasyAutocomplete = (function(scope) {
 									
 									listBuilders = listBuilderService.convertXml(listBuilders);
 
-
-									//TODO
-									if (checkInputPhraseMatchResponse(inputPhrase, data)) {
+									if (capturedRequestCount === remoteRequestCount) {
 
 										listBuilders = listBuilderService.processData(listBuilders, inputPhrase);
 
@@ -585,28 +584,7 @@ var EasyAutocomplete = (function(scope) {
 
 							return settings;
 						}
-
-						function checkInputPhraseMatchResponse(inputPhrase, data) {
-
-							if (config.get("matchResponseProperty") !== false) {
-								if (typeof config.get("matchResponseProperty") === "string") {
-									return (data[config.get("matchResponseProperty")] === inputPhrase);
-								}
-
-								if (typeof config.get("matchResponseProperty") === "function") {
-									return (config.get("matchResponseProperty")(data) === inputPhrase);
-								}
-
-								return true;
-							} else {
-								return true;
-							}
-
-						}
-
 					}
-
-
 				});
 			}
 


### PR DESCRIPTION
Hi,

I have started using the autocomplete on my new site and I have found a problem where the incorrect results for the entered search term are shown. The matchResponseProperty does not correctly work. The issue can be recreated by making two remote requests for data and having the first request response after the second. For example make two requests for "Tes" and "Test", if "Test" responses first the autocomplete will show the correct results. However when the response for "Tes" arrives after, these results are shown, this is incorrect as the input box contains "Test". This issue particularly affects mobile connections with slow connections.

The error comes about because the inputPhrase is captured before the ajax request and is not reread from the input box on the ajax response. I have replaced this functionality with a simple counter "remoteRequestCount". The counter is captured into a local variable and then rechecked against the state. This also has the befits of not having the users having to include matchResponseProperty in there servers response. 

I am sorry but I have only altered the source files. I am an expired developer but not in the javascript world and could not get my grunt build going in the time I had.

Thank you
Dan

